### PR TITLE
for having multibyte content settings.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ paginate = 20
 staticDir = "blog-entry/static"
 title = "Eutech Blog"
 theme = "robust"
+hasCjkLanguage = true
 
 [outputs]
 page = [ "HTML", "AMP" ]


### PR DESCRIPTION
<img width="404" alt="screen shot 2017-09-04 at 16 47 30" src="https://user-images.githubusercontent.com/6571653/30016598-c2558c6e-9190-11e7-80ee-1a3e53000f23.png">

<img width="412" alt="screen shot 2017-09-04 at 16 46 39" src="https://user-images.githubusercontent.com/6571653/30016570-a3a6582a-9190-11e7-9fba-1b5536c56eb2.png">

description overflowed 😭 

and I think robust should have description suffix (for example [...]) 🤔 